### PR TITLE
Fix return type of emscripten_glfw_is_window_fullscreen

### DIFF
--- a/src/cpp/glfw3.cpp
+++ b/src/cpp/glfw3.cpp
@@ -781,7 +781,7 @@ void emscripten_glfw_set_next_window_canvas_selector(char const *canvasSelector)
 //------------------------------------------------------------------------
 // emscripten_glfw_is_window_fullscreen
 //------------------------------------------------------------------------
-int emscripten_glfw_is_window_fullscreen(GLFWwindow* window)
+EM_BOOL emscripten_glfw_is_window_fullscreen(GLFWwindow* window)
 {
   auto w = getWindow(window);
   if(w)


### PR DESCRIPTION
I'm trying to change the type of EM_BOOL and this is currently blocking that:
  https://github.com/emscripten-core/emscripten/pull/22155