### PR TITLE
Fix Issue #27: onScaleChange() does not re-register MQL event listener with new DPR

### DIFF
--- a/src/js/lib_emscripten_glfw3.js
+++ b/src/js/lib_emscripten_glfw3.js
@@ -42,6 +42,13 @@ let emscripten_glfw3_impl = {
       if(GLFW3.fScaleChangeCallback) {
         {{{ makeDynCall('vp', 'GLFW3.fScaleChangeCallback') }}}(GLFW3.fContext);
       }
+
+      // Re-register MQL with current DPR so subsequent zoom changes are detected.
+      if(GLFW3.fScaleMQL) {
+        GLFW3.fScaleMQL.removeEventListener('change', GLFW3.onScaleChange);
+      }
+      GLFW3.fScaleMQL = window.matchMedia('(resolution: ' + window.devicePixelRatio + 'dppx)');
+      GLFW3.fScaleMQL.addEventListener('change', GLFW3.onScaleChange);
     },
 
     //! onWindowResize

--- a/src/js/lib_emscripten_glfw3.js
+++ b/src/js/lib_emscripten_glfw3.js
@@ -43,7 +43,7 @@ let emscripten_glfw3_impl = {
         {{{ makeDynCall('vp', 'GLFW3.fScaleChangeCallback') }}}(GLFW3.fContext);
       }
 
-      // Re-register MQL with current DPR so subsequent zoom changes are detected.
+      // Re-register MQL with current DPR so subsequent scale changes are detected.
       if(GLFW3.fScaleMQL) {
         GLFW3.fScaleMQL.removeEventListener('change', GLFW3.onScaleChange);
       }


### PR DESCRIPTION
This PR fixes issue #27 by re-registering MQL with current DPR so subsequent scale changes are detected.